### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An MCP (Model Context Protocol) server implementation that enhances AI model capabilities with structured, retrieval-augmented thinking processes. This server enables dynamic thought chains, parallel exploration paths, and recursive refinement cycles for improved reasoning and problem-solving.
 
+<a href="https://glama.ai/mcp/servers/d86f2s9wmm">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/d86f2s9wmm/badge" alt="Retrieval-Augmented Thinking Server MCP server" />
+</a>
+
 ## Features
 
 - **Adaptive Thought Chains**: Maintains coherent reasoning flows with branching and revision capabilities


### PR DESCRIPTION
This PR adds a badge for the [Retrieval-Augmented Thinking MCP Server](https://glama.ai/mcp/servers/d86f2s9wmm) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/d86f2s9wmm">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/d86f2s9wmm/badge" alt="Retrieval-Augmented Thinking Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.